### PR TITLE
Verify sync hypotheses with frame decode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ clean:
 	rm -rf bin
 
 # Basic loopback test (mod → demod)
-test: all test-codec
+test: all test-codec test-sync-resolver
 	@echo "=== Pipe Loopback Test ==="
 	@$(BINDIR)/opv-mod -S W5NYV -B 5 | $(BINDIR)/opv-demod -s 2>&1 | grep -E "Station|Token|Summary"
 
@@ -187,6 +187,11 @@ test-codec: all
 	  && diff -q /tmp/codec_frame.txt tests/golden_frame.txt >/dev/null \
 	  && echo "  PASS: impulse 171/133 + frame matches golden" \
 	  || (echo "  FAIL: codec drifted"; exit 1)
+
+test-sync-resolver: | $(BINDIR)
+	@echo "=== Sync hypothesis resolver ==="
+	@$(CXX) $(CXXFLAGS) -Isrc tests/sync_resolver.cpp -o $(BINDIR)/sync_resolver
+	@$(BINDIR)/sync_resolver
 
 
 # LEO Doppler stress test — worst case for satellite demodulator performance.

--- a/src/opv_demod.hpp
+++ b/src/opv_demod.hpp
@@ -1144,28 +1144,7 @@ public:
     // is where the protocol's sync knowledge lives -- NOT in the demodulator, so
     // the demod stays reusable under a different framing.
     static std::vector<double> resolve(const std::vector<double>& dec0,
-                                       const std::vector<double>& dec1) {
-        double pat[SYNC_BITS];
-        for (size_t i = 0; i < SYNC_BITS; ++i) {
-            int bit = (SYNC_WORD >> (SYNC_BITS - 1 - i)) & 1;
-            pat[i] = (bit == 1) ? -1.0 : +1.0;
-        }
-        const std::vector<double>* str[2] = { &dec0, &dec1 };
-        double best = -1.0; int bp = 0; double bs = 1.0;
-        for (int p = 0; p < 2; ++p) {
-            const std::vector<double>& d = *str[p];
-            if (d.size() < SYNC_BITS) continue;
-            for (size_t pos = 0; pos + SYNC_BITS <= d.size(); ++pos) {
-                double sum = 0.0, en = 1e-9;
-                for (size_t j = 0; j < SYNC_BITS; ++j) { double v = d[pos+j]; sum += pat[j]*v; en += std::fabs(v); }
-                double c = sum / en;                       // normalized; sign = polarity
-                if (std::fabs(c) > best) { best = std::fabs(c); bp = p; bs = (c < 0) ? -1.0 : 1.0; }
-            }
-        }
-        std::vector<double> out = *str[bp];
-        if (bs < 0) for (double& x : out) x = -x;
-        return out;
-    }
+                                       const std::vector<double>& dec1);
 
 private:
     // Soft correlation: returns normalized correlation (-1 to +1)
@@ -1425,6 +1404,108 @@ public:
 private:
     ViterbiDecoder vit_;
 };
+
+inline std::vector<double> SyncTracker::resolve(const std::vector<double>& dec0,
+                                                const std::vector<double>& dec1) {
+    std::array<double, SYNC_BITS> pattern;
+    for (size_t i = 0; i < SYNC_BITS; ++i) {
+        const int bit = (SYNC_WORD >> (SYNC_BITS - 1 - i)) & 1;
+        pattern[i] = (bit == 1) ? -1.0 : +1.0;
+    }
+
+    struct Hypothesis {
+        const std::vector<double>* stream = nullptr;
+        size_t sync_pos = 0;
+        double polarity = 1.0;
+        double correlation = -1.0;
+        int metric = -1;
+    };
+
+    const std::vector<double>* streams[2] = {&dec0, &dec1};
+    std::array<Hypothesis, 2> hypotheses;
+    bool have_decodable_hypothesis = false;
+
+    const auto find_peak = [&pattern](const std::vector<double>& stream,
+                                      size_t last_sync) {
+        Hypothesis hypothesis;
+        hypothesis.stream = &stream;
+        for (size_t pos = 0; pos <= last_sync; ++pos) {
+            double sum = 0.0;
+            double energy = 1e-9;
+            for (size_t j = 0; j < SYNC_BITS; ++j) {
+                const double value = stream[pos + j];
+                sum += pattern[j] * value;
+                energy += std::fabs(value);
+            }
+            const double correlation = sum / energy;
+            if (std::fabs(correlation) > hypothesis.correlation) {
+                hypothesis.sync_pos = pos;
+                hypothesis.polarity = (correlation < 0.0) ? -1.0 : 1.0;
+                hypothesis.correlation = std::fabs(correlation);
+            }
+        }
+        return hypothesis;
+    };
+
+    for (int parity = 0; parity < 2; ++parity) {
+        const std::vector<double>& stream = *streams[parity];
+
+        // A candidate needs a complete encoded frame after its sync word. A
+        // peak at the end of a capture cannot be verified and must not displace
+        // an earlier, decodable peak.
+        if (stream.size() < SYNC_BITS + ENCODED_BITS) continue;
+        const size_t last_sync = stream.size() - SYNC_BITS - ENCODED_BITS;
+        Hypothesis& hypothesis = hypotheses[parity];
+        hypothesis = find_peak(stream, last_sync);
+
+        std::array<double, ENCODED_BITS> payload;
+        const size_t payload_pos = hypothesis.sync_pos + SYNC_BITS;
+        for (size_t i = 0; i < ENCODED_BITS; ++i)
+            payload[i] = hypothesis.polarity * stream[payload_pos + i];
+
+        FrameDecoder decoder;
+        std::array<uint8_t, FRAME_BYTES> decoded;
+        hypothesis.metric = decoder.decode(payload.data(), decoded);
+        have_decodable_hypothesis |= hypothesis.metric >= 0;
+    }
+
+    if (have_decodable_hypothesis) {
+        const Hypothesis* best = nullptr;
+        for (const Hypothesis& hypothesis : hypotheses) {
+            if (hypothesis.metric < 0) continue;
+            if (best == nullptr || hypothesis.metric < best->metric ||
+                (hypothesis.metric == best->metric &&
+                 hypothesis.correlation > best->correlation)) {
+                best = &hypothesis;
+            }
+        }
+        std::vector<double> out = *best->stream;
+        if (best->polarity < 0.0)
+            for (double& value : out) value = -value;
+        return out;
+    }
+
+    // Preserve the correlation-only behavior for short captures and
+    // zero-energy payloads where no complete frame can be decoded yet.
+    double best_correlation = -1.0;
+    int best_parity = 0;
+    double best_polarity = 1.0;
+    for (int parity = 0; parity < 2; ++parity) {
+        const std::vector<double>& stream = *streams[parity];
+        if (stream.size() < SYNC_BITS) continue;
+        const Hypothesis hypothesis = find_peak(stream, stream.size() - SYNC_BITS);
+        if (hypothesis.correlation > best_correlation) {
+            best_correlation = hypothesis.correlation;
+            best_parity = parity;
+            best_polarity = hypothesis.polarity;
+        }
+    }
+
+    std::vector<double> out = *streams[best_parity];
+    if (best_polarity < 0.0)
+        for (double& value : out) value = -value;
+    return out;
+}
 
 //------------------------------------------------------------------------------
 // ChannelReceiver - high-level per-channel orchestration (streaming)
@@ -1773,4 +1854,3 @@ public:
 private:
     std::vector<SingleStreamDecodeReceiver> rx_;
 };
-

--- a/tests/sync_resolver.cpp
+++ b/tests/sync_resolver.cpp
@@ -1,0 +1,124 @@
+#include "opv_demod.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+std::array<uint8_t, ENCODED_BITS> make_valid_codeword() {
+    std::array<uint8_t, FRAME_BITS> bits{};
+    uint32_t state = 0x6d2b79f5u;
+    for (uint8_t& bit : bits) {
+        state = state * 1664525u + 1013904223u;
+        bit = static_cast<uint8_t>(state >> 31);
+    }
+
+    auto advance = [](uint8_t& shift, uint8_t bit, uint8_t& g1, uint8_t& g2) {
+        const uint8_t full = static_cast<uint8_t>((bit << 6) | shift);
+        g1 = static_cast<uint8_t>(__builtin_parity(full & G1_MASK));
+        g2 = static_cast<uint8_t>(__builtin_parity(full & G2_MASK));
+        shift = static_cast<uint8_t>(((shift << 1) | bit) & 0x3f);
+    };
+
+    uint8_t shift = 0;
+    uint8_t unused_g1 = 0, unused_g2 = 0;
+    for (uint8_t bit : bits) advance(shift, bit, unused_g1, unused_g2);
+
+    std::array<uint8_t, ENCODED_BITS> convolutional{};
+    size_t index = 0;
+    for (uint8_t bit : bits) {
+        uint8_t g1 = 0, g2 = 0;
+        advance(shift, bit, g1, g2);
+        convolutional[index++] = g1;
+        convolutional[index++] = g2;
+    }
+
+    std::array<uint8_t, ENCODED_BITS> on_air{};
+    for (size_t i = 0; i < ENCODED_BITS; ++i)
+        on_air[deinterleave_addr(i)] = convolutional[i];
+    return on_air;
+}
+
+void put_sync(std::vector<double>& stream, size_t pos, double amplitude) {
+    for (size_t i = 0; i < SYNC_BITS; ++i) {
+        const bool bit = ((SYNC_WORD >> (SYNC_BITS - 1 - i)) & 1u) != 0;
+        stream[pos + i] = bit ? -amplitude : amplitude;
+    }
+}
+
+double sync_correlation(const std::vector<double>& stream, size_t pos) {
+    double sum = 0.0;
+    double energy = 1e-9;
+    for (size_t i = 0; i < SYNC_BITS; ++i) {
+        const bool bit = ((SYNC_WORD >> (SYNC_BITS - 1 - i)) & 1u) != 0;
+        const double expected = bit ? -1.0 : 1.0;
+        sum += expected * stream[pos + i];
+        energy += std::fabs(stream[pos + i]);
+    }
+    return std::fabs(sum / energy);
+}
+
+bool same_stream(const std::vector<double>& lhs, const std::vector<double>& rhs) {
+    if (lhs.size() != rhs.size()) return false;
+    for (size_t i = 0; i < lhs.size(); ++i)
+        if (std::fabs(lhs[i] - rhs[i]) > 1e-12) return false;
+    return true;
+}
+
+}  // namespace
+
+int main() {
+    constexpr size_t correct_sync_pos = 7;
+    constexpr size_t wrong_sync_pos = 6;
+    const size_t stream_size = correct_sync_pos + SYNC_BITS + ENCODED_BITS;
+
+    std::vector<double> correct(stream_size, 0.25);
+    std::vector<double> wrong(stream_size, 0.25);
+    put_sync(correct, correct_sync_pos, 1.0);
+    put_sync(wrong, wrong_sync_pos, 2.0);
+
+    const auto codeword = make_valid_codeword();
+    for (size_t i = 0; i < ENCODED_BITS; ++i)
+        correct[correct_sync_pos + SYNC_BITS + i] = codeword[i] ? -1.0 : 1.0;
+
+    uint32_t noise = 0x94d049bbu;
+    for (size_t i = 0; i < ENCODED_BITS; ++i) {
+        noise = noise * 1103515245u + 12345u;
+        wrong[wrong_sync_pos + SYNC_BITS + i] = (noise >> 31) ? -1.0 : 1.0;
+    }
+
+    // The wrong sync has twice the energy, so the old correlation-only rule
+    // rated its nominally perfect peak a few ULPs higher. Decode verification
+    // must still select the valid parity stream.
+    if (!(sync_correlation(wrong, wrong_sync_pos) >
+          sync_correlation(correct, correct_sync_pos))) {
+        std::fprintf(stderr, "test fixture does not reproduce the correlation tie-break\n");
+        return 1;
+    }
+    const std::vector<double> resolved = SyncTracker::resolve(correct, wrong);
+    if (!same_stream(resolved, correct)) {
+        std::fprintf(stderr, "decode-verified resolver selected the wrong parity\n");
+        return 1;
+    }
+
+    // A short capture cannot contain a frame. It must retain the legacy
+    // correlation-only behavior, including polarity correction.
+    std::vector<double> short_dec0(SYNC_BITS, 0.1);
+    std::vector<double> short_dec1(SYNC_BITS, 0.1);
+    put_sync(short_dec1, 0, -3.0);
+    const std::vector<double> short_resolved = SyncTracker::resolve(short_dec0, short_dec1);
+    for (size_t i = 0; i < SYNC_BITS; ++i) {
+        const bool bit = ((SYNC_WORD >> (SYNC_BITS - 1 - i)) & 1u) != 0;
+        const double expected = bit ? -3.0 : 3.0;
+        if (std::fabs(short_resolved[i] - expected) > 1e-12) {
+            std::fprintf(stderr, "short-capture fallback changed behavior\n");
+            return 1;
+        }
+    }
+
+    std::puts("PASS: decode-verified sync resolution");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- resolve parity and polarity ambiguity with a decoded-frame metric instead of sync correlation alone
- keep the existing correlation-only behavior when a capture is too short to contain a complete frame
- add a deterministic regression test for two nominally perfect sync peaks where the wrong hypothesis wins the floating-point tie

## Root cause

Both parity streams can reproduce a perfect normalized sync correlation, offset by one symbol. The previous resolver therefore selected between them using floating-point noise even though one hypothesis decoded to a valid frame and the other produced garbage.

The resolver now finds the strongest complete-frame candidate in each parity stream, applies its inferred polarity, decodes one frame, and chooses the lower Viterbi metric. Correlation remains the deterministic tie-breaker for equal metrics.

## Validation

- `make test` — codec KAT, resolver regression, and pipe loopback pass; loopback decodes 4/4 perfect frames
- strict C++17 build with `-Wall -Wextra -Wpedantic -Werror`
- AddressSanitizer and UndefinedBehaviorSanitizer run of the resolver regression

Closes #13.
